### PR TITLE
maxResults Configurable Fixes #15

### DIFF
--- a/Jira.SDK.Tests/MockData/MockJiraClient.cs
+++ b/Jira.SDK.Tests/MockData/MockJiraClient.cs
@@ -1430,7 +1430,7 @@ namespace Jira.SDK.Tests
             return _sprints[agileBoardID].Where(sprint => sprint.ID == sprintID).FirstOrDefault();
 		}
 
-		public List<Issue> SearchIssues(string jql)
+		public List<Issue> SearchIssues(string jql, int maxResults)
 		{
             return new List<Issue>();
 		}

--- a/Jira.SDK/Domain/IssueFilter.cs
+++ b/Jira.SDK/Domain/IssueFilter.cs
@@ -4,34 +4,28 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Jira.SDK.Domain
-{
-    public class IssueFilter
-    {
-		private Jira _jira { get; set; }
-		public Jira GetJira()
-		{
-			return _jira;
-		}
+namespace Jira.SDK.Domain {
+    public class IssueFilter {
+        private Jira _jira { get; set; }
+        public Jira GetJira() {
+            return _jira;
+        }
 
-		public void SetJira(Jira jira)
-		{
-			_jira = jira;
-		}
+        public void SetJira(Jira jira) {
+            _jira = jira;
+        }
 
         public String Name { get; set; }
         public String Description { get; set; }
         public String JQL { get; set; }
 
         private List<Issue> _issues;
-        public List<Issue> GetIssues()
-        {
-                if (_issues == null)
-                {
-                    _issues = _jira.Client.SearchIssues(this.JQL);
-                    _issues.ForEach(issue => issue.SetJira(this._jira));
-                }
-                return _issues;
+        public List<Issue> GetIssues(Int32 maxResults = 700) {
+            if (_issues == null) {
+                _issues = _jira.Client.SearchIssues(this.JQL, maxResults);
+                _issues.ForEach(issue => issue.SetJira(this._jira));
+            }
+            return _issues;
         }
     }
 }

--- a/Jira.SDK/Domain/IssueFilter.cs
+++ b/Jira.SDK/Domain/IssueFilter.cs
@@ -4,8 +4,10 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Jira.SDK.Domain {
-    public class IssueFilter {
+namespace Jira.SDK.Domain
+{
+    public class IssueFilter
+    {
         private Jira _jira { get; set; }
         public Jira GetJira()
         {
@@ -23,7 +25,7 @@ namespace Jira.SDK.Domain {
 
         private List<Issue> _issues;
         public List<Issue> GetIssues(Int32 maxResults = 700)
-            {
+        {
             if (_issues == null)
             {
                 _issues = _jira.Client.SearchIssues(this.JQL, maxResults);

--- a/Jira.SDK/Domain/IssueFilter.cs
+++ b/Jira.SDK/Domain/IssueFilter.cs
@@ -7,11 +7,13 @@ using System.Threading.Tasks;
 namespace Jira.SDK.Domain {
     public class IssueFilter {
         private Jira _jira { get; set; }
-        public Jira GetJira() {
+        public Jira GetJira()
+        {
             return _jira;
         }
 
-        public void SetJira(Jira jira) {
+        public void SetJira(Jira jira)
+        {
             _jira = jira;
         }
 
@@ -20,8 +22,10 @@ namespace Jira.SDK.Domain {
         public String JQL { get; set; }
 
         private List<Issue> _issues;
-        public List<Issue> GetIssues(Int32 maxResults = 700) {
-            if (_issues == null) {
+        public List<Issue> GetIssues(Int32 maxResults = 700)
+            {
+            if (_issues == null)
+            {
                 _issues = _jira.Client.SearchIssues(this.JQL, maxResults);
                 _issues.ForEach(issue => issue.SetJira(this._jira));
             }

--- a/Jira.SDK/IJiraClient.cs
+++ b/Jira.SDK/IJiraClient.cs
@@ -38,7 +38,7 @@ namespace Jira.SDK
 		List<Issue> GetIssuesFromSprint(Int32 sprintID);
 
 		Issue GetIssue(String key);
-		List<Issue> SearchIssues(String jql);
+		List<Issue> SearchIssues(String jql, Int32 maxResults);
 
 		Issue AddIssue(IssueFields fields);
 		Comment AddCommentToIssue(Issue issue, Comment comment);

--- a/Jira.SDK/Jira.cs
+++ b/Jira.SDK/Jira.cs
@@ -109,9 +109,9 @@ namespace Jira.SDK
 			return issue;
 		}
 
-        public List<Issue> SearchIssues(String jql)
+        public List<Issue> SearchIssues(String jql, Int32 maxResults = 700)
         {
-            List<Issue> issues = Client.SearchIssues(jql);
+            List<Issue> issues = Client.SearchIssues(jql, maxResults);
             issues.ForEach(issue => issue.SetJira(this));
             return issues;
         }

--- a/Jira.SDK/JiraClient.cs
+++ b/Jira.SDK/JiraClient.cs
@@ -104,9 +104,9 @@ namespace Jira.SDK
             return Client.BaseUrl.ToString();
         }
 
-        public List<Issue> SearchIssues(String jql)
+        public List<Issue> SearchIssues(String jql, Int32 maxResults=700)
         {
-            return GetIssues(_methods[JiraObjectEnum.Issues], new Dictionary<String, String>() { { "jql", jql }, { "maxResults", "700" }, { "fields", "*all" }, { "expand", "transitions" } });
+            return GetIssues(_methods[JiraObjectEnum.Issues], new Dictionary<String, String>() { { "jql", jql }, { "maxResults", maxResults.ToString() }, { "fields", "*all" }, { "expand", "transitions" } });
         }
 
         #region Groups


### PR DESCRIPTION
Makes max results from JQL queries configurable, while maintaining the existing default of 700 results.