### PR TITLE
Support for loading more than around 1000 issues (internal paging)

### DIFF
--- a/Jira.SDK/JiraClient.cs
+++ b/Jira.SDK/JiraClient.cs
@@ -106,7 +106,13 @@ namespace Jira.SDK
 
         public List<Issue> SearchIssues(String jql, Int32 maxResults=700)
         {
-            return GetIssues(_methods[JiraObjectEnum.Issues], new Dictionary<String, String>() { { "jql", jql }, { "maxResults", maxResults.ToString() }, { "fields", "*all" }, { "expand", "transitions" } });
+            Int32 _maxResults;
+            List<Issue> _issues = new List<Issue>();
+            for (int startAt = 0; maxResults > startAt && _issues.Count() == startAt; startAt += 1000) {
+                _maxResults = Math.Min(maxResults - startAt, 1000);
+                _issues.AddRange(GetIssues(_methods[JiraObjectEnum.Issues], new Dictionary<String, String>() { { "jql", jql }, { "maxResults", _maxResults.ToString() }, { "startAt", startAt.ToString() }, { "fields", "*all" }, { "expand", "transitions" } }));
+            }
+            return _issues;
         }
 
         #region Groups


### PR DESCRIPTION
As described in https://confluence.atlassian.com/jirakb/changing-maxresults-parameter-for-jira-rest-api-779160706.html, the Jira API only supports loading up to 1000 Issues in one request.
This pull request extends the SearchIssues to page through the results.
It will respect the existing maxResults parameter and stop sending further requests once no more issues are available (by checking for _issues.Count() == startAt in the for loop condition).