### PR TITLE
Fixed issue with deserializing custom field ids

### DIFF
--- a/Jira.SDK/Domain/CustomField.cs
+++ b/Jira.SDK/Domain/CustomField.cs
@@ -8,7 +8,7 @@ namespace Jira.SDK.Domain
 {
 	public class CustomField
 	{
-		public Int32 ID { get; set; }
+		public string ID { get; set; }
 		public String Value { get; set; }
         
 
@@ -16,11 +16,11 @@ namespace Jira.SDK.Domain
 
         public CustomField(String value)
         {
-            this.ID = 0;
+            this.ID = "0";
             this.Value = value;
         }
 
-        public CustomField(Int32 id, String value)
+        public CustomField(string id, String value)
         {
             this.ID = id;
             this.Value = value;


### PR DESCRIPTION
Jira.SDK was returning errors related to deserializing IDs on a custom field.  Looking through the API documentation, IDs are returned as a string type.  Changed type to be more in line with documentation, which fixed my issue.

This is a breaking change for existing consumers of Jira.SDK, and while it fixes this specific instance, there could be other places where a non-integer ID is returned.